### PR TITLE
Minor string suggestions

### DIFF
--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -33,7 +33,7 @@ msgstr "API Token"
 
 msgid "plugins.generic.dataverse.settings.tokenDescription"
 msgstr "API token for integration with Dataverse.<br>"
-"For more information on how to obtain the API token, please refer to:"
+"For more information on how to obtain the API token, please refer to the "
 "<a href=\"https://guides.dataverse.org/en/5.13/user/account.html#api-token\" target=\"_new\">Dataverse User Guide</a>."
 
 msgid "plugins.generic.dataverse.settings.termsOfUse"
@@ -49,7 +49,7 @@ msgid "plugins.generic.dataverse.settings.additionalInstructionsDescription"
 msgstr "Additional instructions for users who are depositing research data into the repository."
 
 msgid "plugins.generic.dataverse.settings.datasetPublish"
-msgstr "Research data publish"
+msgstr "Research Data Publish"
 
 msgid "plugins.generic.dataverse.settings.datasetPublishDescription"
 msgstr "Select the event where research data will be published to the Dataverse."
@@ -125,7 +125,7 @@ msgstr "The subject of the research data is required. "
 "Please ensure that you have chosen the subject of the research data in the “For the Editors” step."
 
 msgid "plugins.generic.dataverse.error.readmeFile.required"
-msgstr "It is mandatory to send a README file, in PDF or TXT format, to accompany the research data files"
+msgstr "It is mandatory to send a README file, in PDF, MD or TXT format, to accompany the research data files"
 
 msgid "plugins.generic.dataverse.error.getFailed"
 msgstr "Error getting research data to Dataverse: {$error}"


### PR DESCRIPTION
A few small suggestions for the text noticed when testing the plugin (and I confirmed `.md` files are working for the README format as well, since they are `text/plain`).